### PR TITLE
Contracts inherit from interfaces, and small changes to parameter names

### DIFF
--- a/contracts/DogeRelay.sol
+++ b/contracts/DogeRelay.sol
@@ -2,8 +2,9 @@ pragma solidity ^0.4.19;
 
 import "./TransactionProcessor.sol";
 import "./IScryptChecker.sol";
+import "./IDogeRelay.sol";
 
-contract DogeRelay {
+contract DogeRelay is IDogeRelay {
 
     enum Network { MAINNET, TESTNET }
 
@@ -157,13 +158,13 @@ contract DogeRelay {
         return 1;
     }
 
-    function scryptVerified(bytes32 _requestId) public returns (uint) {
+    function scryptVerified(bytes32 _proposalId) public returns (uint) {
         if (msg.sender != address(scryptChecker)) {
             StoreHeader(0, ERR_INVALID_HEADER);
             return 0;
         }
 
-        BlockInformation storage bi = onholdBlocks[uint(_requestId)];
+        BlockInformation storage bi = onholdBlocks[uint(_proposalId)];
 
         uint blockSha256Hash = m_dblShaFlip(bi._blockHeader);
 
@@ -232,7 +233,7 @@ contract DogeRelay {
         myblocks[blockSha256Hash] = bi;
         m_saveAncestors(blockSha256Hash, hashPrevBlock);  // increments ibIndex
 
-        delete onholdBlocks[uint(_requestId)];
+        delete onholdBlocks[uint(_proposalId)];
 
         // https://en.bitcoin.it/wiki/Difficulty
         // Min difficulty for bitcoin is 0x1d00ffff

--- a/contracts/IDogeRelay.sol
+++ b/contracts/IDogeRelay.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.4.19;
 
 interface IDogeRelay {
-    function scryptVerified(bytes32 _requestId) public returns (uint);
+    function scryptVerified(bytes32 _proposalId) public returns (uint);
 }

--- a/contracts/IScryptChecker.sol
+++ b/contracts/IScryptChecker.sol
@@ -6,5 +6,5 @@ interface IScryptChecker {
     // @param _hash – result of applying scrypt to data.
     // @param _submitter – the address of the submitter.
     // @param _reqid – request identifier of the call.
-    function checkScrypt(bytes _data, bytes32 _hash, address _submitter, bytes32 _reqid) public payable returns (uint);
+    function checkScrypt(bytes _data, bytes32 _hash, address _submitter, bytes32 _proposalId) public payable;
 }

--- a/contracts/ScryptCheckerDummy.sol
+++ b/contracts/ScryptCheckerDummy.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.4.19;
 
 import "./IDogeRelay.sol";
+import "./IScryptChecker.sol";
 
-contract ScryptCheckerDummy {
+contract ScryptCheckerDummy is IScryptChecker {
     // DogeRelay
     IDogeRelay public dogeRelay;
 
@@ -43,15 +44,15 @@ contract ScryptCheckerDummy {
     // @param _hash – result of applying scrypt to data.
     // @param _submitter – the address of the submitter.
     // @param _requestId – request identifier of the call.
-    function checkScrypt(bytes _data, bytes32 _hash, address _submitter, bytes32 _requestId) public payable returns (uint) {
+    function checkScrypt(bytes _data, bytes32 _hash, address _submitter, bytes32 _proposalId) public payable {
         if (acceptAll || hashStorage[keccak256(_data)] == _hash) {
-            dogeRelay.scryptVerified(_requestId);
+            dogeRelay.scryptVerified(_proposalId);
         } else {
             pendingRequests[_hash] = ScryptHashRequest({
                 data: _data,
                 hash: _hash,
                 submitter: _submitter,
-                id: _requestId
+                id: _proposalId
             });
         }
     }


### PR DESCRIPTION
Made some small changes to the parameter names in the interfaces for better integration on our end.

contracts are inheriting from interfaces now